### PR TITLE
Fix VRM full backfill when recent windows are empty

### DIFF
--- a/dvhub/history-import.js
+++ b/dvhub/history-import.js
@@ -7,6 +7,7 @@ const VRM_BACKFILL_CHUNK_DAYS = 7;
 const VRM_GAP_BACKFILL_LOOKBACK_DAYS = 7;
 const VRM_GAP_BACKFILL_CHUNK_DAYS = 1;
 const VRM_BACKFILL_EMPTY_WINDOW_LIMIT = 2;
+const VRM_FULL_BACKFILL_MAX_LOOKBACK_DAYS = 365;
 const VRM_BACKFILL_DELAY_MS = 500;
 const VRM_BACKFILL_RETRY_ATTEMPTS = 3;
 const VRM_BACKFILL_RETRY_DELAY_MS = 1000;
@@ -1484,8 +1485,10 @@ export function createHistoryImportManager({
     chunkDays = VRM_BACKFILL_CHUNK_DAYS,
     delayMs = VRM_BACKFILL_DELAY_MS,
     maxEmptyWindows = VRM_BACKFILL_EMPTY_WINDOW_LIMIT,
+    maxLookbackDays = VRM_FULL_BACKFILL_MAX_LOOKBACK_DAYS,
     interval = VRM_HISTORY_INTERVAL,
-    auto = false
+    auto = false,
+    allowIntervalFallback = true
   } = {}) {
     const validation = validateConfiguredVrmImport({ requireRange: false });
     if (!validation.ok) return validation;
@@ -1493,21 +1496,30 @@ export function createHistoryImportManager({
     let cursorEnd = startOfUtcDayIso(now ? toIso(now) : new Date().toISOString());
     let windowsVisited = 0;
     let importedWindows = 0;
+    let emptyWindows = 0;
     let trailingEmptyWindows = 0;
     let importedRows = 0;
     let requestedFrom = null;
     const requestedTo = cursorEnd;
+    const normalizedChunkDays = Math.max(1, Number(chunkDays || VRM_BACKFILL_CHUNK_DAYS));
+    const normalizedMaxLookbackDays = Math.max(1, Number(maxLookbackDays || VRM_FULL_BACKFILL_MAX_LOOKBACK_DAYS));
+    const normalizedInterval = normalizeVrmInterval(interval);
+    const oldestAllowed = shiftIsoByDays(requestedTo, -normalizedMaxLookbackDays);
+    let foundAnyData = false;
 
-    while (trailingEmptyWindows < maxEmptyWindows) {
+    while (new Date(cursorEnd).getTime() > new Date(oldestAllowed).getTime()) {
       const windowEnd = cursorEnd;
-      const windowStart = shiftIsoByDays(windowEnd, -Math.max(1, Number(chunkDays || VRM_BACKFILL_CHUNK_DAYS)));
+      let windowStart = shiftIsoByDays(windowEnd, -normalizedChunkDays);
+      if (new Date(windowStart).getTime() < new Date(oldestAllowed).getTime()) {
+        windowStart = oldestAllowed;
+      }
       requestedFrom = windowStart;
       windowsVisited += 1;
 
       const fetched = await fetchConfiguredVrmRows({
         start: windowStart,
         end: windowEnd,
-        interval
+        interval: normalizedInterval
       });
       if (!fetched.ok) return fetched;
 
@@ -1515,14 +1527,34 @@ export function createHistoryImportManager({
         store.writeSamples(fetched.rows);
         importedWindows += 1;
         importedRows += fetched.rows.length;
+        foundAnyData = true;
         trailingEmptyWindows = 0;
       } else {
-        trailingEmptyWindows += 1;
+        emptyWindows += 1;
+        if (foundAnyData) {
+          trailingEmptyWindows += 1;
+        }
       }
 
       cursorEnd = windowStart;
-      if (trailingEmptyWindows >= maxEmptyWindows) break;
-      await waitImpl(delayMs);
+      if (foundAnyData && trailingEmptyWindows >= maxEmptyWindows) break;
+      if (new Date(cursorEnd).getTime() <= new Date(oldestAllowed).getTime()) break;
+      if (foundAnyData) {
+        await waitImpl(delayMs);
+      }
+    }
+
+    if (!foundAnyData && importedRows === 0 && allowIntervalFallback && normalizedInterval === '15mins') {
+      return runVrmFullBackfill({
+        now,
+        chunkDays: normalizedChunkDays,
+        delayMs,
+        maxEmptyWindows,
+        maxLookbackDays: normalizedMaxLookbackDays,
+        interval: 'days',
+        auto,
+        allowIntervalFallback: false
+      });
     }
 
     const importConfig = telemetryConfig.historyImport || {};
@@ -1535,14 +1567,16 @@ export function createHistoryImportManager({
       sourceAccount: importConfig.vrmPortalId,
       meta: {
         provider: 'vrm',
-        interval,
+        interval: normalizedInterval,
         auto,
         mode: 'full',
-        chunkDays,
+        chunkDays: normalizedChunkDays,
+        maxLookbackDays: normalizedMaxLookbackDays,
         maxEmptyWindows,
         windowsVisited,
         importedWindows,
-        emptyWindows: trailingEmptyWindows
+        emptyWindows,
+        foundAnyData
       }
     });
     const priceBackfill = await maybeBackfillPricesForRange({
@@ -1561,7 +1595,7 @@ export function createHistoryImportManager({
       requestedTo,
       windowsVisited,
       importedWindows,
-      emptyWindows: trailingEmptyWindows,
+      emptyWindows,
       importedRows,
       priceBackfill
     };

--- a/dvhub/test/history-import.test.js
+++ b/dvhub/test/history-import.test.js
@@ -1429,12 +1429,141 @@ test('VRM backfill job walks chunked windows until repeated empty history and wa
     assert.equal(result.partial, false);
     assert.equal(result.windowsVisited, 5);
     assert.equal(result.importedWindows, 2);
-    assert.equal(result.emptyWindows, 2);
+    assert.equal(result.emptyWindows, 3);
     assert.equal(result.importedRows > 0, true);
     assert.equal(store.countRows('timeseries_samples', "series_key = 'pv_total_w'"), 2);
     assert.equal(store.countRows('import_jobs', "job_type = 'vrm_history_full_backfill'"), 1);
-    assert.deepEqual(waits, [50, 50, 50, 50]);
+    assert.deepEqual(waits, [50, 50, 50]);
     assert.equal(requests.length, 15);
+  } finally {
+    store.close();
+  }
+});
+
+test('VRM full backfill continues past initial empty windows and can still find older VRM data', async () => {
+  const store = createStore();
+  const waits = [];
+  const windowsWithData = new Set([
+    '2026-03-02T00:00:00.000Z|2026-03-03T00:00:00.000Z'
+  ]);
+  const fetchImpl = async (url) => {
+    const parsed = new URL(url);
+    const type = parsed.searchParams.get('type');
+    const start = new Date(Number(parsed.searchParams.get('start')) * 1000).toISOString();
+    const end = new Date(Number(parsed.searchParams.get('end')) * 1000).toISOString();
+    const key = `${start}|${end}`;
+    const hasData = windowsWithData.has(key);
+    return {
+      ok: true,
+      async json() {
+        return hasData && type === 'venus'
+          ? {
+            records: {
+              Pdc: [[Date.parse(start), 1000]]
+            }
+          }
+          : { records: {} };
+      }
+    };
+  };
+
+  try {
+    const manager = createHistoryImportManager({
+      store,
+      fetchImpl,
+      waitImpl: async (ms) => {
+        waits.push(ms);
+      },
+      telemetryConfig: {
+        historyImport: {
+          enabled: true,
+          provider: 'vrm',
+          vrmPortalId: '12345',
+          vrmToken: 'token123'
+        }
+      }
+    });
+
+    const result = await manager.backfillHistoryFromConfiguredSource({
+      mode: 'full',
+      now: '2026-03-05T00:00:00.000Z',
+      chunkDays: 1,
+      delayMs: 50,
+      maxEmptyWindows: 2,
+      maxLookbackDays: 10
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.importedWindows, 1);
+    assert.equal(result.importedRows > 0, true);
+    assert.equal(result.windowsVisited, 5);
+    assert.equal(result.emptyWindows, 4);
+    assert.deepEqual(waits, [50, 50]);
+  } finally {
+    store.close();
+  }
+});
+
+test('VRM full backfill falls back to days interval when 15mins returns no rows', async () => {
+  const store = createStore();
+  const seenIntervals = [];
+  const windowsWithData = new Set([
+    '2026-03-02T00:00:00.000Z|2026-03-03T00:00:00.000Z'
+  ]);
+
+  const fetchImpl = async (url) => {
+    const parsed = new URL(url);
+    const type = parsed.searchParams.get('type');
+    const interval = parsed.searchParams.get('interval');
+    const start = new Date(Number(parsed.searchParams.get('start')) * 1000).toISOString();
+    const end = new Date(Number(parsed.searchParams.get('end')) * 1000).toISOString();
+    const key = `${start}|${end}`;
+    seenIntervals.push(interval);
+
+    const hasData = interval === 'days' && windowsWithData.has(key);
+    return {
+      ok: true,
+      async json() {
+        return hasData && type === 'venus'
+          ? {
+            records: {
+              Pdc: [[Date.parse(start), 1000]]
+            }
+          }
+          : { records: {} };
+      }
+    };
+  };
+
+  try {
+    const manager = createHistoryImportManager({
+      store,
+      fetchImpl,
+      waitImpl: async () => {},
+      telemetryConfig: {
+        historyImport: {
+          enabled: true,
+          provider: 'vrm',
+          vrmPortalId: '12345',
+          vrmToken: 'token123'
+        }
+      }
+    });
+
+    const result = await manager.backfillHistoryFromConfiguredSource({
+      mode: 'full',
+      now: '2026-03-05T00:00:00.000Z',
+      chunkDays: 1,
+      maxEmptyWindows: 2,
+      maxLookbackDays: 10,
+      interval: '15mins'
+    });
+
+    assert.equal(result.ok, true);
+    assert.equal(result.importedWindows, 1);
+    assert.equal(result.importedRows > 0, true);
+    assert.equal(seenIntervals.includes('15mins'), true);
+    assert.equal(seenIntervals.includes('days'), true);
   } finally {
     store.close();
   }
@@ -1476,7 +1605,9 @@ test('VRM full backfill aligns windows to UTC day boundaries even from a mid-day
       mode: 'full',
       now: '2026-03-05T11:55:30.047Z',
       chunkDays: 1,
-      maxEmptyWindows: 2
+      maxEmptyWindows: 2,
+      maxLookbackDays: 2,
+      allowIntervalFallback: false
     });
 
     assert.equal(result.ok, true);
@@ -1526,7 +1657,9 @@ test('VRM full backfill forwards requested interval to VRM fetches', async () =>
         now: '2026-03-05T00:00:00.000Z',
         chunkDays: 1,
         maxEmptyWindows: 1,
-        interval
+        maxLookbackDays: 1,
+        interval,
+        allowIntervalFallback: false
       });
       assert.equal(result.ok, true);
       assert.deepEqual(seenIntervals, [interval, interval, interval]);


### PR DESCRIPTION
## Problem
In setups where VRM telemetry is only available in older periods, the "VM/VRM backfill" in the app can report:

- `importedRows: 0`
- `windowsVisited: 0/2` (or very early stop)

Two root causes were identified:
1. Full backfill stopped after `maxEmptyWindows` from "now", even before reaching older windows that contain data.
2. Some portals return no rows for `15mins`, while `days` has data.

## What this changes
### Runtime behavior (`dvhub/history-import.js`)
- Adds bounded deep-search horizon for full backfills:
  - `VRM_FULL_BACKFILL_MAX_LOOKBACK_DAYS = 365`
  - new option `maxLookbackDays`
- Full backfill now:
  - scans backwards through initial empty windows until data is found (or lookback horizon is reached)
  - applies `maxEmptyWindows` only **after first data window**
- Adds interval fallback for full backfill:
  - if `15mins` finds no data at all, automatically retries with `days` once
- Stores richer metadata:
  - `maxLookbackDays`, `foundAnyData`, normalized interval

### Tests (`dvhub/test/history-import.test.js`)
- Updates full-backfill expectations for empty-window accounting/waits.
- Adds regression test for "initial empty windows, older data exists".
- Adds regression test for `15mins -> days` fallback.
- Full suite remains green.

## Validation
Executed successfully:
- `node --test test/history-import.test.js`
- `npm test`

## Outcome
Backfill no longer gets stuck at the latest empty windows and now recovers historical VRM data in stale-recent setups.
